### PR TITLE
More debug messages around interacting with the database

### DIFF
--- a/repository/postgres/read_category.go
+++ b/repository/postgres/read_category.go
@@ -61,12 +61,17 @@ func (r postgresRepo) GetAllMessagesInCategorySince(ctx context.Context, categor
 		}
 
 		if len(msgs) == 0 {
+			logrus.WithFields(map[string]interface{}{
+				"category": category,
+			}).Debug("read nothing from category")
 			retChan <- returnPair{[]*repository.MessageEnvelope{}, nil}
 			return
 		}
 
 		for _, msg := range msgs {
-			logrus.Debugf("read from category %s", msg.StreamName)
+			logrus.WithFields(map[string]interface{}{
+				"category": category,
+			}).Debugf("read from category %s", msg.StreamName)
 		}
 
 		retChan <- returnPair{msgs, nil}

--- a/repository/postgres/read_category.go
+++ b/repository/postgres/read_category.go
@@ -2,6 +2,7 @@ package postgres
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"github.com/blackhatbrigade/gomessagestore/repository"
@@ -45,6 +46,14 @@ func (r postgresRepo) GetAllMessagesInCategorySince(ctx context.Context, categor
 		)*/
 
 		query := "SELECT * FROM get_category_messages($1, $2, $3)"
+		logrus.WithFields(map[string]interface{}{
+			"query": query,
+			"params": []string{
+				category,
+				fmt.Sprintf("%d", globalPosition),
+				fmt.Sprintf("%d", batchSize),
+			},
+		}).Debug("Running query on DB")
 		if err := r.dbx.SelectContext(ctx, &msgs, query, category, globalPosition, batchSize); err != nil {
 			logrus.WithError(err).Error("Failure in repo_postgres.go::GetAllMessagesInCategorySince")
 			retChan <- returnPair{nil, err}
@@ -54,6 +63,10 @@ func (r postgresRepo) GetAllMessagesInCategorySince(ctx context.Context, categor
 		if len(msgs) == 0 {
 			retChan <- returnPair{[]*repository.MessageEnvelope{}, nil}
 			return
+		}
+
+		for _, msg := range msgs {
+			logrus.Debugf("read from category %s", msg.StreamName)
 		}
 
 		retChan <- returnPair{msgs, nil}

--- a/repository/postgres/read_stream.go
+++ b/repository/postgres/read_stream.go
@@ -112,6 +112,7 @@ func (r postgresRepo) GetAllMessagesInStreamSince(ctx context.Context, streamNam
 		}
 
 		if len(msgs) == 0 {
+			logrus.Debugf("read nothing from stream %s", streamName)
 			retChan <- returnPair{[]*repository.MessageEnvelope{}, nil}
 			return
 		}

--- a/repository/postgres/read_stream.go
+++ b/repository/postgres/read_stream.go
@@ -2,6 +2,7 @@ package postgres
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/blackhatbrigade/gomessagestore/repository"
 	"github.com/sirupsen/logrus"
@@ -31,6 +32,12 @@ func (r postgresRepo) GetLastMessageInStream(ctx context.Context, streamName str
 		  _stream_name varchar,
 		)*/
 		query := "SELECT * FROM get_last_message($1)"
+		logrus.WithFields(map[string]interface{}{
+			"query": query,
+			"params": []string{
+				streamName,
+			},
+		}).Debug("Running query on DB")
 		if err := r.dbx.SelectContext(ctx, &msgs, query, streamName); err != nil {
 			logrus.WithError(err).Error("Failure in repo_postgres.go::GetLastMessageInStream")
 			retChan <- returnPair{nil, err}
@@ -40,6 +47,10 @@ func (r postgresRepo) GetLastMessageInStream(ctx context.Context, streamName str
 		if len(msgs) == 0 {
 			retChan <- returnPair{[]*repository.MessageEnvelope{nil}, nil}
 			return
+		}
+
+		for _, msg := range msgs {
+			logrus.Debugf("read from stream %s", msg.StreamName)
 		}
 
 		retChan <- returnPair{msgs, nil}
@@ -87,6 +98,13 @@ func (r postgresRepo) GetAllMessagesInStreamSince(ctx context.Context, streamNam
 		  _condition varchar DEFAULT NULL
 		)*/
 		query := "SELECT * FROM get_stream_messages($1, $2)"
+		logrus.WithFields(map[string]interface{}{
+			"query": query,
+			"params": []string{
+				streamName,
+				fmt.Sprintf("%d", globalPosition),
+			},
+		}).Debug("Running query on DB")
 		if err := r.dbx.SelectContext(ctx, &msgs, query, streamName, globalPosition); err != nil {
 			logrus.WithError(err).Error("Failure in repo_postgres.go::GetAllMessagesInStreamSince")
 			retChan <- returnPair{nil, err}
@@ -96,6 +114,10 @@ func (r postgresRepo) GetAllMessagesInStreamSince(ctx context.Context, streamNam
 		if len(msgs) == 0 {
 			retChan <- returnPair{[]*repository.MessageEnvelope{}, nil}
 			return
+		}
+
+		for _, msg := range msgs {
+			logrus.Debugf("read from stream %s", msg.StreamName)
 		}
 
 		retChan <- returnPair{msgs, nil}

--- a/repository/postgres/writes.go
+++ b/repository/postgres/writes.go
@@ -85,6 +85,8 @@ func (r postgresRepo) writeMessageEitherWay(ctx context.Context, msg *repository
 				return
 			}
 		}
+
+		logrus.Debugf("wrote successfully to stream %s", msg.StreamName)
 	}()
 
 	// wait for our return channel or the context to cancel

--- a/repository/postgres/writes.go
+++ b/repository/postgres/writes.go
@@ -2,6 +2,7 @@ package postgres
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/blackhatbrigade/gomessagestore/repository"
 	"github.com/blackhatbrigade/gomessagestore/uuid"
@@ -53,6 +54,15 @@ func (r postgresRepo) writeMessageEitherWay(ctx context.Context, msg *repository
 
 			// with _expected_version passed in
 			query := "SELECT write_message($1, $2, $3, $4, $5, $6)"
+			logrus.WithFields(logrus.Fields{
+				"query":              query,
+				"ID":                 msg.ID,
+				"StreamName":         msg.StreamName,
+				"MessageMessageType": msg.MessageType,
+				"Data":               string(msg.Data),
+				"MessageMetadata":    string(msg.Metadata),
+				"ExpectedVersion":    fmt.Sprintf("%d", position[0]),
+			}).Debug("about to write message")
 			if _, err := r.dbx.ExecContext(ctx, query, msg.ID, msg.StreamName, msg.MessageType, msg.Data, msg.Metadata, position[0]); err != nil {
 				logrus.WithError(err).Error("Failure in repo_postgres.go::WriteMessageWithExpectedPosition")
 				retChan <- err


### PR DESCRIPTION
If the global level for logrus is set to Debug or lower, Debug messages are logged before and after each interaction with the PostgreSQL DB.