### PR TITLE
adds an error to the return from the Reduce() function

### DIFF
--- a/helpers_test.go
+++ b/helpers_test.go
@@ -374,14 +374,14 @@ type mockReducer1 struct {
 	ReceivedMessage Message
 }
 
-func (red *mockReducer1) Reduce(msg Message, previousState interface{}) interface{} {
+func (red *mockReducer1) Reduce(msg Message, previousState interface{}) (interface{}, error) {
 	switch state := previousState.(type) {
 	case mockDataStructure:
 		state.MockReducer1Called = true
 		state.MockReducer1CallCount++
-		return state
+		return state, nil
 	}
-	return nil
+	return nil, nil
 }
 
 func (red *mockReducer1) Type() string {
@@ -393,14 +393,14 @@ type mockReducer2 struct {
 	ReceivedMessage Message
 }
 
-func (red *mockReducer2) Reduce(msg Message, previousState interface{}) interface{} {
+func (red *mockReducer2) Reduce(msg Message, previousState interface{}) (interface{}, error) {
 	switch state := previousState.(type) {
 	case mockDataStructure:
 		state.MockReducer2Called = true
 		state.MockReducer2CallCount++
-		return state
+		return state, nil
 	}
-	return nil
+	return nil, nil
 }
 
 func (red *mockReducer2) Type() string {

--- a/message_reducer.go
+++ b/message_reducer.go
@@ -4,7 +4,7 @@ package gomessagestore
 
 //MessageReducer Defines the expected behaviours of a reducer that ultimately is used by the projectors.
 type MessageReducer interface {
-	Reduce(msg Message, previousState interface{}) interface{}
+	Reduce(msg Message, previousState interface{}) (interface{}, error)
 	Type() string
 }
 
@@ -15,7 +15,7 @@ type MessageReducerConfig struct {
 }
 
 //MessageReducerFunc is a functional way to create a reducer (for use with WithReducerFunc)
-type MessageReducerFunc func(msg Message, previousState interface{}) interface{}
+type MessageReducerFunc func(msg Message, previousState interface{}) (interface{}, error)
 
 type genericReducer struct {
 	msgType string
@@ -26,6 +26,6 @@ func (g *genericReducer) Type() string {
 	return g.msgType
 }
 
-func (g *genericReducer) Reduce(msg Message, previousState interface{}) interface{} {
+func (g *genericReducer) Reduce(msg Message, previousState interface{}) (interface{}, error) {
 	return g.msgFunc(msg, previousState)
 }

--- a/mocks/message_reducer.go
+++ b/mocks/message_reducer.go
@@ -34,11 +34,12 @@ func (m *MockMessageReducer) EXPECT() *MockMessageReducerMockRecorder {
 }
 
 // Reduce mocks base method
-func (m *MockMessageReducer) Reduce(arg0 gomessagestore.Message, arg1 interface{}) interface{} {
+func (m *MockMessageReducer) Reduce(arg0 gomessagestore.Message, arg1 interface{}) (interface{}, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Reduce", arg0, arg1)
 	ret0, _ := ret[0].(interface{})
-	return ret0
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // Reduce indicates an expected call of Reduce

--- a/mocks/projector.go
+++ b/mocks/projector.go
@@ -66,12 +66,13 @@ func (mr *MockProjectorMockRecorder) RunOnStream(arg0, arg1 interface{}) *gomock
 }
 
 // Step mocks base method
-func (m *MockProjector) Step(arg0 gomessagestore.Message, arg1 interface{}) (interface{}, bool) {
+func (m *MockProjector) Step(arg0 gomessagestore.Message, arg1 interface{}) (interface{}, bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Step", arg0, arg1)
 	ret0, _ := ret[0].(interface{})
 	ret1, _ := ret[1].(bool)
-	return ret0, ret1
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
 }
 
 // Step indicates an expected call of Step


### PR DESCRIPTION
This is a breaking change, but we're still prerelease, so I'm not super worried.